### PR TITLE
requiring the wrong querystring

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,7 @@
     "retsly/socket.io-client":"1.1.1",
     "segmentio/extend": "1.0.0",
     "component/each": "0.2.5",
-    "tj/node-querystring": "0.6.6",
+    "retsly/qs": "v2.3.4",
     "component/cookie": "1.0.1",
     "component/emitter": "1.1.3"
   },

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var extend = require('extend');
 var io = require('socket.io-client');
 var ajax = require('ajax');
 var each = require('each');
-var qs = require('querystring').stringify;
+var qs = require('qs').stringify;
 var store = require('cookie');
 var emitter = require('emitter');
 


### PR DESCRIPTION
 in our code we require('querystring') but in the package.json dependency is qs.
    some other intern module has another querystring dependency thus it does not throw an error   
 querystirng is broken, qs is not ( doesn not convert nested objects into property query param string)