### PR TITLE
Error callback's parameter list does not match with component-ajax

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,8 @@ Retsly.prototype.request = function(method, url, query, cb) {
       if (window.XMLHttpRequest && !window.XDomainRequest)
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     },
-    error: function(res, status, xhr) {
+    error: function(xhr, type, settings) {
+      var res = xhr.responseText ? JSON.parse(xhr.responseText) : xhr;
       log(method, url, query, res);
       self.validateSession(res.status);
       if(typeof cb === 'function') cb(res);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retsly-js-sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": {
     "name": "Retsly",
     "email": "support@rets.ly"


### PR DESCRIPTION
In component-ajax, the arguments passed into the error callback are (xhr, type, error). https://github.com/ForbesLindesay/ajax/blob/master/index.js#L139 However, in our error callback in the sdk, our accepted parameters are in wrong order (res, status, xhr). Thus, all error responses received using the sdk is actually the xhr response.